### PR TITLE
Fix `pip install -e .` creates only the dist-info not the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
    name='edbo',
-   packages=['edbo'], 
+   packages=find_packages(), 
    version='0.2.0',
    author='Jose A. Garrido Torres & Abigail Gutmann Doyle',
    author_email='josegarridotorres@me.com',


### PR DESCRIPTION
Hi

I found `pip install -e .` creates only the dist-info not the package...
So I send this pull requests!

Regards!