### PR TITLE
Performance improvements

### DIFF
--- a/edbo/plus/optimizer_botorch.py
+++ b/edbo/plus/optimizer_botorch.py
@@ -94,7 +94,8 @@ class EDBOplus:
             scaler_features=MinMaxScaler(),
             scaler_objectives=EDBOStandardScaler(),
             acquisition_function='EHVI',
-            acquisition_function_sampler='SobolQMCNormalSampler'):
+            acquisition_function_sampler='SobolQMCNormalSampler',
+            write_extra_data=True):
 
         """
         Parameters
@@ -332,7 +333,8 @@ class EDBOplus:
         #     Not inplace:        11.118995329999962 sec
         original_df = original_df.sort_values(cols_sort, ascending=False)
         # Save extra df containing predictions, uncertainties and EI.
-        # original_df.to_csv(f"{directory}/pred_{filename}", index=False)
+        if write_extra_data:
+            original_df.to_csv(f"{directory}/pred_{filename}", index=False)
 
         # Drop predictions, uncertainties and EI.
         original_df = original_df.drop(columns=cols_for_preds, axis='columns')

--- a/edbo/plus/optimizer_botorch.py
+++ b/edbo/plus/optimizer_botorch.py
@@ -95,7 +95,7 @@ class EDBOplus:
             scaler_objectives=EDBOStandardScaler(),
             acquisition_function='EHVI',
             acquisition_function_sampler='SobolQMCNormalSampler',
-            write_extra_data=True):
+            write_extra_data=False):
 
         """
         Parameters

--- a/edbo/plus/optimizer_botorch.py
+++ b/edbo/plus/optimizer_botorch.py
@@ -95,7 +95,7 @@ class EDBOplus:
             scaler_objectives=EDBOStandardScaler(),
             acquisition_function='EHVI',
             acquisition_function_sampler='SobolQMCNormalSampler',
-            write_extra_data=False):
+            write_extra_data=True):
 
         """
         Parameters

--- a/edbo/plus/optimizer_botorch.py
+++ b/edbo/plus/optimizer_botorch.py
@@ -24,9 +24,13 @@ from pathlib import Path
 from botorch.sampling.samplers import SobolQMCNormalSampler, IIDNormalSampler
 from edbo.plus.utils import EDBOStandardScaler
 
+import time
+
+print("Device:", 'cuda' if torch.cuda.is_available() else 'cpu')
+
 tkwargs = {
     "dtype": torch.double,
-    "device": torch.device("cpu"),
+    "device": torch.device('cuda' if torch.cuda.is_available() else 'cpu'),
 }
 
 
@@ -43,9 +47,11 @@ class EDBOplus:
         """
         Creates a reaction scope from a dictionary of components and values.
         """
+        start_gen_rxn_scope = time.perf_counter()
         df = create_reaction_scope(components=components, directory=directory,
                                    filename=filename,
                                    check_overwrite=check_overwrite)
+        print("Generating reaction scope; Time: {} sec".format(time.perf_counter() - start_gen_rxn_scope))
         return df
 
     @staticmethod
@@ -164,6 +170,8 @@ class EDBOplus:
 
         """
 
+        start_run = time.perf_counter()
+
         wdir = Path(directory)
         csv_filename = wdir.joinpath(filename)
         torch.manual_seed(seed=seed)
@@ -171,6 +179,7 @@ class EDBOplus:
         self.acquisition_sampler = acquisition_function_sampler
 
         # 1. Safe checks.
+        start_safe_checks = time.perf_counter()
         self.objective_names = objectives
         # Check whether the columns_features contains the objectives.
         if columns_features != 'all':
@@ -191,7 +200,12 @@ class EDBOplus:
         msg = "Scope was not found. Please create an scope (csv file)."
         assert os.path.exists(csv_filename), msg
 
+        end_safe_checks = time.perf_counter()
+        print("Safe checks; Time: {} sec".format(end_safe_checks - start_safe_checks))
+
         # 2. Load reaction.
+        start_load_rxn = time.perf_counter()
+
         df = pd.read_csv(f"{csv_filename}")
         df = df.dropna(axis='columns', how='all')
         original_df = df.copy(deep=True)  # Make a copy of the original data.
@@ -233,9 +247,15 @@ class EDBOplus:
             original_df.to_csv(csv_filename, index=False)
             return original_df
 
+        end_load_rxn = time.perf_counter()
+        print("Load Reaction; Time: {} sec".format(end_load_rxn - start_load_rxn))
+
         # 3. Separate train and test data.
 
+        start_separate_data = time.perf_counter()
+
         # 3.1. Auto-detect dummy features (one-hot-encoding).
+        start_dummy_features = time.perf_counter()
         numeric_cols = df._get_numeric_data().columns
         for nc in numeric_cols:
             df[nc] = pd.to_numeric(df[nc], downcast='float')
@@ -249,9 +269,30 @@ class EDBOplus:
 
         data = pd.get_dummies(df, prefix=ohe_columns, columns=ohe_columns, drop_first=True)
 
+        end_dummy_features = time.perf_counter()
+        print("  Dummy Features; Time: {} sec".format(end_dummy_features - start_dummy_features))
+
         # 3.2. Any sample with a value 'PENDING' in any objective is a test.
-        idx_test = (data[data.apply(lambda r: r.str.contains('PENDING', case=False).any(), axis=1)]).index.values
-        idx_train = (data[~data.apply(lambda r: r.str.contains('PENDING', case=False).any(), axis=1)]).index.values
+        start_scope = time.perf_counter()
+
+        # Calculating 'internal_df' takes 99.6% of the time for section 3.2
+        # This is 40x slower than the new calculation of 'internal_df'
+        # Using data with the shape (22650, 4), the timings are as follows:
+        #     Old implementation: 4.231292907999887 sec
+        #     New implementation: 0.12133147600070515 sec
+        # internal_df = data.apply(lambda r: r.str.contains('PENDING', case=False).any(), axis=1)
+        start_internal_df = time.perf_counter()
+        internal_df = data.apply(lambda r: 'PENDING' in r, axis=1, raw=True)
+        print("  internal_df; Time: {} sec".format(time.perf_counter() - start_internal_df))
+        # Using data of shape (2085136, 6), 12,510,816 elements:
+        #     Time: 11.925687787 sec (98.3x speedup from 0.1213314760 sec)
+        #     Size: 12,510,816 elements (138.1x size increase from 90600)
+        #     Speed of approximately 1.4 elements/sec
+
+        start_old_filtering = time.perf_counter()
+        idx_test = (data[internal_df]).index.values
+        idx_train = (data[~internal_df]).index.values
+        print("  Old Filtering; Time: {} sec".format(time.perf_counter() - start_old_filtering))
 
         # Data only contains featurized information (train and test).
         df_train_y = data.loc[idx_train][objectives]
@@ -268,8 +309,13 @@ class EDBOplus:
                   'value and then press run.'
             print(msg)
             return original_df
+        
+        end_scope = time.perf_counter()
+        print("  Scope?; Time: {} sec".format(end_scope - start_scope))
+
 
         # Run the BO process.
+        start_model_run = time.perf_counter()
         priority_list = self._model_run(
                 data=data,
                 df_train_x=df_train_x,
@@ -283,7 +329,11 @@ class EDBOplus:
                 scaler_y=scaler_objectives,
                 acquisition_function=acquisition_function
         )
+        end_model_run = time.perf_counter()
+        print("  Model Run; Time: {} sec".format(end_model_run - start_model_run))
 
+
+        start_attach_objectives = time.perf_counter()
         # Low priority to the samples that have been already collected.
         for i in range(0, len(idx_train)):
             priority_list[idx_train[i]] = -1
@@ -307,13 +357,34 @@ class EDBOplus:
                                    ])
         cols_for_preds = np.ravel(cols_for_preds)
 
+        end_attach_objectives = time.perf_counter()
+        print("  Attach Objectives; Time: {} sec".format(end_attach_objectives - start_attach_objectives))
+
+
+        # Writing data of shape (2085136, 9), 18,766,224 elements and
+        # (2085136, 6), 12,510,816 elements, for a total of 31,277,040
+        # elements:
+        #     Not inplace:        26.374841521999997 sec
+        #     inplace:            25.059074194999994 sec
+        #     chunksize=1000:     24.801981217000048 sec
+        #     chunksize=100000:   25.093697998000152 sec
+        #     chunksize=1000000:  25.457136616999833 sec
+        # If the shape (2085136, 9), 18,766,224 elements is not written:
+        #     Not inplace:        11.118995329999962 sec
+        start_writing_csv = time.perf_counter()
         original_df = original_df.sort_values(cols_sort, ascending=False)
         # Save extra df containing predictions, uncertainties and EI.
-        original_df.to_csv(f"{directory}/pred_{filename}", index=False)
+        # original_df.to_csv(f"{directory}/pred_{filename}", index=False)
+
         # Drop predictions, uncertainties and EI.
         original_df = original_df.drop(columns=cols_for_preds, axis='columns')
         original_df = original_df.sort_values(cols_sort, ascending=False)
         original_df.to_csv(csv_filename, index=False)
+
+        end_separate_data = time.perf_counter()
+        print("  Writing CSV; Time: {} sec".format(end_separate_data - start_writing_csv))
+        print("Separate Data; Time: {} sec".format(end_separate_data - start_separate_data))
+        print("Total run(); Time: {} sec".format(end_separate_data - start_run))
 
         return original_df
 

--- a/edbo/plus/optimizer_botorch.py
+++ b/edbo/plus/optimizer_botorch.py
@@ -24,13 +24,9 @@ from pathlib import Path
 from botorch.sampling.samplers import SobolQMCNormalSampler, IIDNormalSampler
 from edbo.plus.utils import EDBOStandardScaler
 
-import time
-
-print("Device:", 'cuda' if torch.cuda.is_available() else 'cpu')
-
 tkwargs = {
     "dtype": torch.double,
-    "device": torch.device('cuda' if torch.cuda.is_available() else 'cpu'),
+    "device": torch.device("cpu"),
 }
 
 

--- a/edbo/plus/optimizer_botorch.py
+++ b/edbo/plus/optimizer_botorch.py
@@ -192,7 +192,6 @@ class EDBOplus:
         assert os.path.exists(csv_filename), msg
 
         # 2. Load reaction.
-
         df = pd.read_csv(f"{csv_filename}")
         df = df.dropna(axis='columns', how='all')
         original_df = df.copy(deep=True)  # Make a copy of the original data.
@@ -234,7 +233,6 @@ class EDBOplus:
             original_df.to_csv(csv_filename, index=False)
             return original_df
 
-
         # 3. Separate train and test data.
 
         # 3.1. Auto-detect dummy features (one-hot-encoding).
@@ -250,7 +248,6 @@ class EDBOplus:
             ohe_features = True
 
         data = pd.get_dummies(df, prefix=ohe_columns, columns=ohe_columns, drop_first=True)
-
 
         # 3.2. Any sample with a value 'PENDING' in any objective is a test.
 
@@ -284,7 +281,7 @@ class EDBOplus:
                   'value and then press run.'
             print(msg)
             return original_df
-        
+
         # Run the BO process.
         priority_list = self._model_run(
                 data=data,


### PR DESCRIPTION
We are currently trying to benchmark reaction optimization algorithms, including EDBO+. However, while benchmarking we noticed that each iteration of EDBO+ was a time-consuming process, especially when we need ~10000 iteration steps per benchmarking function. After some performance profiling, we found and optimized a few sections to help speed up the process.

The first improvement was achieved by optimizing calculating the training and testing indicies in `EDBOplus.run()`. This ended up speeding up each `EDBOplus.run()` call by 40x. To do this, I removed a redundant calculation of `internal_df` and used a more efficient lookup method for rows containing "PENDING" to create it.

Additionally, I added an extra, optional parameter to `EDBOplus.run()` called `write_extra_data` to make writing the predictions file at each step optional. This helps save time, since the file can be quite large depending upon your reaction space. To maintain status quo, I made the default value `True` so the prediction file is still written.

I also included some comments about the details of the timing improvements for reference, but they can be removed if necessary.