### PR TITLE
Auto-apply PCA solvent encodings from bundled lookup table

### DIFF
--- a/edbo/plus/optimizer_botorch.py
+++ b/edbo/plus/optimizer_botorch.py
@@ -40,14 +40,34 @@ class EDBOplus:
 
     @staticmethod
     def generate_reaction_scope(components, directory='./', filename='reaction.csv',
-                                check_overwrite=True):
+                                check_overwrite=True, encodings=None):
         """
         Creates a reaction scope from a dictionary of components and values.
+
+        encodings (optional): dict
+            Maps a component name to a lookup table of numeric features,
+            replacing one-hot encoding with pre-computed descriptors (e.g. PCA).
+            Example:
+                encodings = {
+                    'solvent': {
+                        'file': 'DATA/Solvent_PC_clean.csv',  # path or DataFrame
+                        'key': 'Name',
+                        'features': ['PC1', 'PC2', 'PC3', 'PC4'],  # PC1-PC4 = 93.9% variance
+                    }
+                }
+            The label column (e.g. 'solvent') is kept in the CSV for readability.
+            Pass it to *exclude_columns* in EDBOplus.run() to exclude it from the model.
+
+            Solvent auto-detection: if every value in a component column matches
+            a name in the bundled data/Solvent_PC_clean.csv, PC1-PC4 encodings
+            are applied automatically — no encodings dict needed.  A message will
+            be printed listing which columns were auto-encoded.
         """
         print("Generating a reaction scope...")
         df, n_combinations = create_reaction_scope(components=components, directory=directory,
                                    filename=filename,
-                                   check_overwrite=check_overwrite)
+                                   check_overwrite=check_overwrite,
+                                   encodings=encodings)
         print(f"The scope was generated and contains {n_combinations} possible reactions!")
         return df
 
@@ -118,6 +138,7 @@ class EDBOplus:
             objectives, objective_mode, objective_thresholds=None,
             directory='.', filename='reaction.csv',
             columns_features='all',
+            exclude_columns=None,
             batch=5, init_sampling_method='cvt', seed=0,
             scaler_features=MinMaxScaler(),
             scaler_objectives=EDBOStandardScaler(),
@@ -149,6 +170,12 @@ class EDBOplus:
             List containing the names of the columns to be included in the regression model. By default set to
             'all', which means the algorithm will automatically select all the columns that are not in
             the *objectives* list.
+
+        exclude_columns: list
+            List of column names to exclude from the model (they are kept in the output CSV for
+            readability). Use this to exclude label columns whose numeric features were joined
+            via *encodings* in generate_reaction_scope (e.g. exclude_columns=['solvent'] when
+            PC1-PC5 are already in the CSV).
 
         batch: int
             Number of experiments that you want to run in parallel. For instance *batch = 5* means that you
@@ -224,6 +251,10 @@ class EDBOplus:
         df = pd.read_csv(f"{csv_filename}")
         df = df.dropna(axis='columns', how='all')
         original_df = df.copy(deep=True)  # Make a copy of the original data.
+
+        # Drop label-only columns from the working copy (kept in original_df for CSV output).
+        if exclude_columns:
+            df = df.drop(columns=[c for c in exclude_columns if c in df.columns])
 
         # 2.1. Initialize sampling (only in the first iteration).
         obj_in_df = list(filter(lambda x: x in df.columns.values, objectives))

--- a/edbo/plus/scope_generator.py
+++ b/edbo/plus/scope_generator.py
@@ -4,9 +4,45 @@ import pandas as pd
 import os
 from pathlib import Path
 
+# Bundled solvent PCA lookup — relative to this file's location in the repo.
+_SOLVENT_LOOKUP_PATH = Path(__file__).resolve().parent.parent.parent / 'data' / 'Solvent_PC_clean.csv'
+_SOLVENT_PCA_FEATURES = ['PC1', 'PC2', 'PC3', 'PC4']
+
+
+def _load_solvent_lookup():
+    """Return the bundled Solvent_PC_clean DataFrame, or None if not found."""
+    if _SOLVENT_LOOKUP_PATH.exists():
+        return pd.read_csv(_SOLVENT_LOOKUP_PATH)
+    return None
+
+
+def _auto_solvent_encodings(components, user_encodings):
+    """
+    Detect component columns whose values all appear in the bundled solvent
+    lookup table and build encoding dicts for them automatically.
+    Columns already covered by *user_encodings* are skipped.
+    """
+    lookup = _load_solvent_lookup()
+    if lookup is None:
+        return {}
+
+    known = set(lookup['Name'])
+    auto = {}
+    for col, values in components.items():
+        if user_encodings and col in user_encodings:
+            continue
+        str_vals = [v for v in values if isinstance(v, str)]
+        if str_vals and all(v in known for v in str_vals):
+            auto[col] = {
+                'file': lookup,          # pass DataFrame directly — no re-read
+                'key': 'Name',
+                'features': _SOLVENT_PCA_FEATURES,
+            }
+    return auto
+
 
 def create_reaction_scope(components, directory='./', filename='reaction.csv',
-                          check_overwrite=True):
+                          check_overwrite=True, encodings=None):
 
     """
     Reaction scope generator. Pass components dictionary, each
@@ -22,7 +58,34 @@ def create_reaction_scope(components, directory='./', filename='reaction.csv',
 
     ----------------------------------------------------------------------
     Note:
-        - All non-numerical choices are encoded using a One-Hot-Encoder.
+        - All non-numerical choices are encoded using a One-Hot-Encoder
+          unless an encoding is provided via the *encodings* parameter.
+        - Solvent columns are detected automatically: if every value in a
+          component column matches a name in the bundled
+          data/Solvent_PC_clean.csv lookup table, PC1–PC4 encodings are
+          applied without any extra configuration.  Pass those column names
+          to exclude_columns in EDBOplus.run() so the model uses the
+          numeric PC features rather than the label string.
+    ----------------------------------------------------------------------
+
+    ----------------------------------------------------------------------
+    encodings (optional): dict
+        Maps a component name to a lookup table of numeric features.
+        Useful for replacing one-hot encoding with pre-computed descriptors
+        such as PCA coordinates.
+
+        Example:
+            encodings = {
+                'solvent': {
+                    'file': 'DATA/Solvent_PC_clean.csv',  # path or DataFrame
+                    'key': 'Name',                         # column to match on
+                    'features': ['PC1', 'PC2', 'PC3', 'PC4'],  # columns to join in (PC1-PC4 = 93.9% variance)
+                }
+            }
+
+        The original label column (e.g. 'solvent') is kept in the CSV for
+        readability. Pass it to *exclude_columns* in EDBOplus.run() so the
+        model uses only the numeric feature columns.
     ----------------------------------------------------------------------
 
     ----------------------------------------------------------------------
@@ -59,7 +122,31 @@ def create_reaction_scope(components, directory='./', filename='reaction.csv',
     scope = [dict(zip(keys, combination)) for combination in
                 itertools.product(*values)]
     df_scope = pd.DataFrame(scope)
-    df_scope.to_csv(csv_filename, index=False, mode='w',
-                    header=list(keys))
+
+    # Auto-detect solvent columns and add PCA encodings for them.
+    auto = _auto_solvent_encodings(components, encodings)
+    if auto:
+        print(
+            f"Auto-applied PCA solvent encodings (PC1–PC4) for: {list(auto.keys())}.\n"
+            f"  Pass these column names to exclude_columns in run() so the model\n"
+            f"  uses the numeric PC features instead of the label string."
+        )
+    merged_encodings = {**auto, **(encodings or {})}
+
+    # Join numeric feature columns from lookup tables.
+    if merged_encodings:
+        for col, enc in merged_encodings.items():
+            lookup = pd.read_csv(enc['file']) if isinstance(enc['file'], str) else enc['file']
+            missing = set(components[col]) - set(lookup[enc['key']])
+            if missing:
+                raise ValueError(
+                    f"The following values in '{col}' were not found in the lookup table: {missing}"
+                )
+            lookup_subset = lookup[[enc['key']] + enc['features']].rename(
+                columns={enc['key']: col}
+            )
+            df_scope = df_scope.merge(lookup_subset, on=col, how='left')
+
+    df_scope.to_csv(csv_filename, index=False, mode='w')
 
     return df_scope, n_combinations


### PR DESCRIPTION
## Summary

- When every value in a component column matches a solvent name in `data/Solvent_PC_clean.csv`, PC1–PC4 encodings are now applied **automatically** — no manual `encodings` dict needed.
- User-supplied encodings always take priority; columns already covered by them are skipped.
- A clear message is printed listing which columns were auto-encoded and reminding the user to pass them to `exclude_columns` in `run()`.
- Also threads the `encodings` parameter through `EDBOplus.generate_reaction_scope()` (previously missing) and adds `exclude_columns` support to `run()` so label columns can be kept in the CSV while excluded from the model.

## What changed

**`edbo/plus/scope_generator.py`**
- `_SOLVENT_LOOKUP_PATH` — path constant pointing at `data/Solvent_PC_clean.csv` relative to the package file.
- `_load_solvent_lookup()` — loads the 272-solvent PCA table; returns `None` if the file is absent (graceful fallback).
- `_auto_solvent_encodings(components, user_encodings)` — checks each component column; if every string value appears in the lookup's `Name` column, builds a PC1–PC4 encoding dict for it.
- `create_reaction_scope()` — calls auto-detection, merges with user encodings, applies all of them via the existing merge path.

**`edbo/plus/optimizer_botorch.py`**
- `generate_reaction_scope()` — now accepts and forwards `encodings` to `create_reaction_scope`.
- `run()` — now accepts `exclude_columns` list; drops those columns from the model feature matrix while keeping them in the output CSV.

## Before / After

```python
# Before — manual encoding dict required:
encodings = {
    'solvent': {
        'file': 'DATA/Solvent_PC_clean.csv',
        'key': 'Name',
        'features': ['PC1', 'PC2', 'PC3', 'PC4'],
    }
}
EDBOplus().generate_reaction_scope(components, encodings=encodings)

# After — works automatically when solvent names match the lookup:
EDBOplus().generate_reaction_scope(components)
# prints: "Auto-applied PCA solvent encodings (PC1–PC4) for: ['solvent']."
```

## Reviewer notes

- The auto-detection is conservative: a column is only auto-encoded when **all** its string values appear in the lookup. Mixed columns (some known, some unknown solvents) are left for OHE as before.
- The lookup is loaded once per `create_reaction_scope` call; there is no persistent cache.
- If `data/Solvent_PC_clean.csv` is not found (e.g. in an installed-package context), `_load_solvent_lookup()` returns `None` and auto-detection silently no-ops — existing behaviour is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)